### PR TITLE
negative variable in Majka_find has to be const

### DIFF
--- a/majkamodule.cpp
+++ b/majkamodule.cpp
@@ -470,7 +470,8 @@ static PyObject* Majka_tags(char * tag_string) {
 static PyObject* Majka_find(Majka* self, PyObject* args, PyObject* kwds) {
   const char* word = NULL;
   char* results = new char[self->majka->max_results_size];
-  char* entry, * colon, * negative;
+  char* entry, * colon; 
+  const char* negative;
   char tmp_lemma[300];
   PyObject* ret = PyList_New(0);
   PyObject* lemma, * tags, * option;


### PR DESCRIPTION
negative variable in Majka_find has to be const otherwise compilation fails as the PyUnicode_AsUTF8 expects const parameter.